### PR TITLE
chore: Use obvious unicode point

### DIFF
--- a/lib/flecks/shell.rb
+++ b/lib/flecks/shell.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Flecks::Shell < Phlex::HTML
-	ZERO_WIDTH_SPACE = "​" # trust me, it’s there! 😅
+	ZERO_WIDTH_SPACE = "\u{200b}"
 	SAFE_BYTES_FOR_SAFARI = Phlex::SGML::SafeValue.new(ZERO_WIDTH_SPACE * 512)
 
 	def initialize(nonce: nil)


### PR DESCRIPTION
Simply makes reading a bit easier even when editor/viewer software does not show non-printable characters.